### PR TITLE
MSelectbox: Support for separating values ​​and names

### DIFF
--- a/src/components/atoms/MSelectbox/MSelectbox.vue
+++ b/src/components/atoms/MSelectbox/MSelectbox.vue
@@ -87,6 +87,10 @@ export default Vue.extend<Data, Methods, Computed, Props>({
       type: Array,
       default: () => []
     },
+    itemValue: {
+      type: String,
+      default: ''
+    },
     itemText: {
       type: String,
       default: ''
@@ -111,9 +115,23 @@ export default Vue.extend<Data, Methods, Computed, Props>({
   },
   computed: {
     setSelectedValue() {
-      return !this.selectedValue
-        ? this.initialSelectedValue
-        : this.selectedValue;
+      if (!this.selectList) return '';
+
+      if (!this.selectedValue) {
+        if (!this.itemValue) return this.initialSelectedValue;
+        const selectedItem = this.selectList.find(
+          element => element[this.itemValue] === this.initialSelectedValue
+        );
+        if (!selectedItem) return '';
+        return selectedItem[this.itemText];
+      } else {
+        if (!this.itemValue) return this.selectedValue;
+        const selectedItem = this.selectList.find(
+          element => element[this.itemValue] === this.selectedValue
+        );
+        if (!selectedItem) return '';
+        return selectedItem[this.itemText];
+      }
     },
     buttonElements() {
       return this.$refs.button;

--- a/src/components/atoms/MSelectbox/types.ts
+++ b/src/components/atoms/MSelectbox/types.ts
@@ -3,6 +3,7 @@ export interface Props {
   initialSelectedValue: string | number;
   selectedValue: string | number;
   selectList: string[]; // It will be reflected as soon as the response is known.
+  itemValue: string;
   itemText: string;
   minWidth: string;
   inputDisabled: boolean;


### PR DESCRIPTION
リストに表示するテキストとリスト選択時に取得できる値を別々にすることができるように修正

- itemValueのpropsを追加
  -  表示されているテキストをvalueとして返さず、valueを取得する際のキーを指定することができる 
- selectedValueのロジックの修正
  - itemValueが指定されている場合に、itemValueのキーを元にvalueを取得するように修正